### PR TITLE
Adicionando AbstractRestApiService para chamadas Rest para API da Bíblia e Ajustando Plugin de Testes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<apache.version>4.5.14</apache.version>
 		<mockito.version>5.8.0</mockito.version>
 		<cloud.version>3.0.5</cloud.version>
+		<easyrandom.version>4.2.0</easyrandom.version>
 	</properties>
 
 	<dependencies>
@@ -28,6 +29,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- commons -->
@@ -74,11 +81,23 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>${mockito.version}</version>
+			<version>5.10.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -89,10 +108,22 @@
             <version>${cloud.version}</version>
         </dependency>
 
-    </dependencies>
+	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.21.0</version>
+				<configuration>
+					<reportFormat>plain</reportFormat>
+					<includes>
+						<include>**/*Test*.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/br/com/luan/barcella/jesus/api/config/RestTemplateConfiguration.java
+++ b/src/main/java/br/com/luan/barcella/jesus/api/config/RestTemplateConfiguration.java
@@ -1,0 +1,27 @@
+package br.com.luan.barcella.jesus.api.config;
+
+import static java.time.Duration.ofMillis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+    @Value("${rest-template.timeout.connect}")
+    private Integer connectTimeout;
+
+    @Value("${rest-template.timeout.read}")
+    private Integer readTimeout;
+
+    @Bean
+    public RestTemplate restTemplate(final RestTemplateBuilder builder) {
+        return builder
+            .setConnectTimeout(ofMillis(connectTimeout))
+            .setReadTimeout(ofMillis(readTimeout))
+            .build();
+    }
+}

--- a/src/main/java/br/com/luan/barcella/jesus/api/domain/Message.java
+++ b/src/main/java/br/com/luan/barcella/jesus/api/domain/Message.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum Message {
 
-    FALHA_INESPERADA("falha.inesperada");
+    FALHA_INESPERADA("falha.inesperada"),
+    SERVICO_INDISPONIVEL("servico.indisponivel");
 
     private final String message;
 

--- a/src/main/java/br/com/luan/barcella/jesus/api/service/rest/AbstractRestApiService.java
+++ b/src/main/java/br/com/luan/barcella/jesus/api/service/rest/AbstractRestApiService.java
@@ -1,0 +1,109 @@
+package br.com.luan.barcella.jesus.api.service.rest;
+
+import static java.util.Arrays.stream;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+import br.com.luan.barcella.jesus.api.domain.ErrorType;
+import br.com.luan.barcella.jesus.api.domain.Message;
+import br.com.luan.barcella.jesus.api.exception.ClientErrorException;
+import br.com.luan.barcella.jesus.api.exception.ServerErrorException;
+import br.com.luan.barcella.jesus.api.service.support.MessageService;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractRestApiService {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Getter
+    @Autowired
+    private MessageService messageService;
+
+    /**
+     * Método que retorna a exception que será jogada. Este pode ser utilizado para personalizar a exception conforme
+     * regras de negocio impostas.
+     *
+     * @param ex Exception retornada pelo RestTemplate.
+     * @return Exception para ser jogada.
+     */
+    protected RuntimeException buildError(final HttpStatusCodeException ex) {
+
+        if (ex.getStatusCode().is5xxServerError()) {
+            log.error("Server error Exception", ex);
+            return new ServerErrorException(messageService.get(Message.SERVICO_INDISPONIVEL), ex);
+        }
+
+        final ErrorType errorType = stream(ErrorType.values())
+            .filter(ert -> ert.getHttpStatus().equals(ex.getStatusCode()))
+            .findFirst()
+            .orElse(ErrorType.BUSINESS);
+
+        final ClientErrorException error = new ClientErrorException(errorType,
+            messageService.get(Message.SERVICO_INDISPONIVEL), ex);
+
+        log.error("Server Error Exception: [message={}, details={}]", error.getMessage(), error.getDetails());
+
+        return error;
+    }
+
+    public <T> T get(final String url, final Class<T> responseClass) {
+        return performRest(url, new HttpHeaders(), null, responseClass, HttpMethod.GET);
+    }
+
+    public <T> T getWithHeaders(final String url, final HttpHeaders headers, final Class<T> responseClass) {
+        return performRest(url, headers, null, responseClass, HttpMethod.GET);
+    }
+
+    public <T> T post(final String url, final HttpHeaders headers, final Class<T> responseClass) {
+        return performRest(url, headers, null, responseClass, HttpMethod.POST);
+    }
+
+    public <T> T postWithBody(final String url, final Object body, final Class<T> responseClass) {
+        return performRest(url, new HttpHeaders(), body, responseClass, HttpMethod.POST);
+    }
+
+    public <T> T postWithHeaders(final String url, final HttpHeaders headers, final Object body, final Class<T> responseClass) {
+        return performRest(url, headers, body, responseClass, HttpMethod.POST);
+    }
+
+
+    public <T> T performRest(final String url, final HttpHeaders headers, final Object body,
+        final Class<T> responseClass, final HttpMethod httpMethod) {
+        try {
+            final HttpEntity<?> httpEntity = new HttpEntity<>(body, headers);
+
+            log.info("REST Request. URL {} : {}", url, httpMethod);
+            final ResponseEntity<T> response = restTemplate.exchange(url, httpMethod, httpEntity, responseClass);
+
+            log.debug("REST Response. {}", ofNullable(response).map(HttpEntity::getBody).orElse(null));
+
+            return ofNullable(response)
+                .map(HttpEntity::getBody)
+                .orElseThrow(() -> {
+                    log.warn("Response nula na chamada.");
+                    return new ServerErrorException(messageService.get(Message.SERVICO_INDISPONIVEL));
+                });
+
+        } catch (final HttpStatusCodeException ex) {
+            log.error("Falha na API para url {}: [httpStatusCode:{}, responseBody:{}]", url,
+                of(ex.getStatusCode()).map(HttpStatusCode::value).orElse(null), ex.getResponseBodyAsString());
+
+            throw buildError(ex);
+        }
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,8 @@ spring:
 
 key:
   final: ${KEY_FINAL:final}
+
+rest-template:
+  timeout:
+    connect: ${REST_TIMEOUT_CONNECT:5000} # 5 segundos em milissegundos
+    read: ${REST_TIMEOUT_READ:15000} # 15 segundos em milissegundos

--- a/src/main/resources/i18n/messages_pt_BR.properties
+++ b/src/main/resources/i18n/messages_pt_BR.properties
@@ -1,1 +1,2 @@
 falha.inesperada=Falha Inesperada.
+servico.indisponivel=Serviço Indisponível.

--- a/src/test/java/br/com/luan/barcella/jesus/api/fixture/Fixture.java
+++ b/src/test/java/br/com/luan/barcella/jesus/api/fixture/Fixture.java
@@ -1,0 +1,29 @@
+package br.com.luan.barcella.jesus.api.fixture;
+
+import org.jeasy.random.EasyRandom;
+
+/**
+ * Classe utilitária usada para a geração de Fixtures (Objetos preenchidos com dados aleatórios).
+ *
+ * Exemplos de uso: Para retornar um objeto preenchido que tenha padrão Builder: Response =
+ * Fixture.make(Response.builder().build());
+ *
+ * Para retornar um objeto preenchido que tenha padrão de Setter/Construtor vazio: Response =
+ * Fixture.make(newResponse());
+ *
+ * Também é possível retornar um builder:
+ *
+ * Response.ResponseBuilder = Fixture.make(Response.builder());
+ *
+ * Este builder retorna com todos os atributos preenchidos, e é possível sobreescrever os atributos que quiser antes de
+ * dar o .build();
+ */
+public class Fixture {
+
+    private static final EasyRandom easyRandom = new EasyRandom();
+
+    @SuppressWarnings("unchecked")
+    public static <T> T make(final T mockClass) {
+        return (T) easyRandom.nextObject(mockClass.getClass());
+    }
+}

--- a/src/test/java/br/com/luan/barcella/jesus/api/service/rest/AbstractRestApiServiceTest.java
+++ b/src/test/java/br/com/luan/barcella/jesus/api/service/rest/AbstractRestApiServiceTest.java
@@ -1,0 +1,311 @@
+package br.com.luan.barcella.jesus.api.service.rest;
+
+import static br.com.luan.barcella.jesus.api.domain.ErrorType.BUSINESS;
+import static br.com.luan.barcella.jesus.api.domain.Message.SERVICO_INDISPONIVEL;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+import br.com.luan.barcella.jesus.api.domain.ErrorType;
+import br.com.luan.barcella.jesus.api.domain.Message;
+import br.com.luan.barcella.jesus.api.exception.ClientErrorException;
+import br.com.luan.barcella.jesus.api.exception.ServerErrorException;
+import br.com.luan.barcella.jesus.api.fixture.Fixture;
+import br.com.luan.barcella.jesus.api.service.support.MessageService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractRestApiServiceTest {
+
+    private AbstractRestApiService service;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private MessageService messageService;
+
+    @Captor
+    private ArgumentCaptor<HttpEntity<?>> httpEntityCaptor;
+
+    private String url;
+
+    private HttpHeaders headers;
+
+    private Object body;
+
+    private String message;
+
+    @Before
+    public void init() {
+        service = new AbstractRestApiService() {
+        };
+
+        setField(service, "restTemplate", restTemplate);
+        setField(service, "messageService", messageService);
+
+        url = randomAlphabetic(20);
+        headers = Fixture.make(new HttpHeaders());
+        body = Fixture.make(new Object());
+        message = randomAlphabetic(10);
+
+        when(messageService.get(any(Message.class)))
+            .thenReturn(message);
+    }
+
+    @Test
+    public void performRestSucesso() {
+        final HttpMethod httpMethod = POST;
+        final Class<Object> responseClass = Object.class;
+        final ResponseEntity<Object> entityResponse = ResponseEntity.ok(new Object());
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenReturn(entityResponse);
+
+        final Object response = service.performRest(url, headers, body, responseClass, httpMethod);
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertEquals(body, httpEntityCaptured.getBody());
+        assertEquals(headers, httpEntityCaptured.getHeaders());
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void performRestResponseBodyNull() {
+        final HttpMethod httpMethod = POST;
+        final Class<Object> responseClass = Object.class;
+        final ResponseEntity<Object> entityResponse = ResponseEntity.ok(null);
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenReturn(entityResponse);
+
+        final ServerErrorException exception = Assertions.assertThrows(ServerErrorException.class, () -> {
+            service.performRest(url, headers, body, responseClass, httpMethod);
+        });
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+        verify(messageService).get(SERVICO_INDISPONIVEL);
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertEquals(body, httpEntityCaptured.getBody());
+        assertEquals(headers, httpEntityCaptured.getHeaders());
+
+        assertNotNull(exception);
+        assertEquals(message, exception.getMessage());
+    }
+
+    @Test
+    public void performRestBuildError5xx() {
+        final HttpMethod httpMethod = POST;
+        final Class<Object> responseClass = Object.class;
+        final HttpStatusCodeException httpStatusCodeException = new HttpClientErrorException(INTERNAL_SERVER_ERROR);
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenThrow(httpStatusCodeException);
+
+        final ServerErrorException exception = Assertions.assertThrows(ServerErrorException.class, () -> {
+            service.performRest(url, headers, body, responseClass, httpMethod);
+        });
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+        verify(messageService).get(SERVICO_INDISPONIVEL);
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertEquals(body, httpEntityCaptured.getBody());
+        assertEquals(headers, httpEntityCaptured.getHeaders());
+
+        assertNotNull(exception);
+        assertEquals(message, exception.getMessage());
+    }
+
+    @Test
+    public void performRestBuildError4xxComErrorTypeMapeado() {
+        final HttpMethod httpMethod = POST;
+        final Class<Object> responseClass = Object.class;
+        final HttpStatusCodeException httpStatusCodeException = new HttpClientErrorException(HttpStatus.NOT_FOUND);
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenThrow(httpStatusCodeException);
+
+        final ClientErrorException exception = Assertions.assertThrows(ClientErrorException.class, () -> {
+            service.performRest(url, headers, body, responseClass, httpMethod);
+        });
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+        verify(messageService).get(SERVICO_INDISPONIVEL);
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertEquals(body, httpEntityCaptured.getBody());
+        assertEquals(headers, httpEntityCaptured.getHeaders());
+
+        assertNotNull(exception);
+        assertEquals(ErrorType.NOT_FOUND, exception.getErrorType());
+        assertEquals(message, exception.getMessage());
+    }
+
+    @Test
+    public void performRestBuildError4xxComErrorTypeNaoMapeado() {
+        final HttpMethod httpMethod = POST;
+        final Class<Object> responseClass = Object.class;
+        final HttpStatusCodeException httpStatusCodeException = new HttpClientErrorException(TOO_MANY_REQUESTS);
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenThrow(httpStatusCodeException);
+
+        final ClientErrorException exception = Assertions.assertThrows(ClientErrorException.class, () -> {
+            service.performRest(url, headers, body, responseClass, httpMethod);
+        });
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+        verify(messageService).get(SERVICO_INDISPONIVEL);
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertEquals(body, httpEntityCaptured.getBody());
+        assertEquals(headers, httpEntityCaptured.getHeaders());
+
+        assertNotNull(exception);
+        assertEquals(BUSINESS, exception.getErrorType());
+        assertEquals(message, exception.getMessage());
+    }
+
+    @Test
+    public void performGetSucesso() {
+        final HttpMethod httpMethod = GET;
+        final Class<Object> responseClass = Object.class;
+        final ResponseEntity<Object> entityResponse = ResponseEntity.ok(new Object());
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenReturn(entityResponse);
+
+        final Object response = service.get(url, responseClass);
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertNull(httpEntityCaptured.getBody());
+        assertTrue(httpEntityCaptured.getHeaders().isEmpty());
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void performGetWithHeadersSucesso() {
+        final HttpMethod httpMethod = GET;
+        final Class<Object> responseClass = Object.class;
+        final ResponseEntity<Object> entityResponse = ResponseEntity.ok(new Object());
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenReturn(entityResponse);
+
+        final Object response = service.getWithHeaders(url, headers, responseClass);
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertNull(httpEntityCaptured.getBody());
+        assertEquals(headers, httpEntityCaptured.getHeaders());
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void performPostSucesso() {
+        final HttpMethod httpMethod = POST;
+        final Class<Object> responseClass = Object.class;
+        final ResponseEntity<Object> entityResponse = ResponseEntity.ok(new Object());
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenReturn(entityResponse);
+
+        final Object response = service.post(url, headers, responseClass);
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertNull(httpEntityCaptured.getBody());
+        assertEquals(headers, httpEntityCaptured.getHeaders());
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void performPostWithBodySucesso() {
+        final HttpMethod httpMethod = POST;
+        final Class<Object> responseClass = Object.class;
+        final ResponseEntity<Object> entityResponse = ResponseEntity.ok(new Object());
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenReturn(entityResponse);
+
+        final Object response = service.postWithBody(url, body, responseClass);
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertEquals(body, httpEntityCaptured.getBody());
+        assertTrue(httpEntityCaptured.getHeaders().isEmpty());
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void performPostWithHeaderSucesso() {
+        final HttpMethod httpMethod = POST;
+        final Class<Object> responseClass = Object.class;
+        final ResponseEntity<Object> entityResponse = ResponseEntity.ok(new Object());
+
+        when(restTemplate.exchange(eq(url), eq(httpMethod), any(HttpEntity.class), eq(responseClass)))
+            .thenReturn(entityResponse);
+
+        final Object response = service.postWithHeaders(url, headers, body, responseClass);
+
+        verify(restTemplate).exchange(eq(url), eq(httpMethod), httpEntityCaptor.capture(), eq(responseClass));
+
+        final HttpEntity<?> httpEntityCaptured = httpEntityCaptor.getValue();
+        assertNotNull(httpEntityCaptured);
+        assertEquals(body, httpEntityCaptured.getBody());
+        assertEquals(headers, httpEntityCaptured.getHeaders());
+
+        assertNotNull(response);
+    }
+
+}

--- a/src/test/java/br/com/luan/barcella/jesus/api/utils/RandomCollectionUtils.java
+++ b/src/test/java/br/com/luan/barcella/jesus/api/utils/RandomCollectionUtils.java
@@ -1,0 +1,48 @@
+package br.com.luan.barcella.jesus.api.utils;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+import static org.apache.commons.lang3.RandomUtils.nextInt;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RandomCollectionUtils {
+
+    public static <T> T pickRandom(final T[] array) {
+        if (isEmpty(array)) {
+            return null;
+        }
+
+        return array[nextInt(0, array.length)];
+    }
+
+    public static <T> List<T> generateList(final Supplier<T> supplier, final int startInclusive,
+        final int endExclusive) {
+        return Stream.generate(supplier).limit(nextInt(startInclusive, endExclusive)).collect(toList());
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T pickRandomExcept(final T[] array, final T exception) {
+        final List<T> list = new ArrayList<>();
+        list.addAll(Arrays.asList(array));
+        list.remove(exception);
+        return pickRandom(list.toArray((T[]) new Object[list.size()]));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T pickRandomExcept(final T[] array, final T[] exceptions) {
+        final List<T> list = new ArrayList<>();
+        list.addAll(Arrays.asList(array));
+        Arrays.asList(exceptions).forEach((e) -> list.remove(e));
+        return pickRandom(list.toArray((T[]) new Object[list.size()]));
+    }
+}
+


### PR DESCRIPTION
**Alterações:**
- Adicionando classe `AbstractRestApiService` para ser utilizada no contato com a API da bíblia digital;
- Ajustando plugin para rodar todos os testes no comando `mvn-clean-install`

### Evidência(s):

#### Evidência de conexão REST com a API da bíblia digital:
![image](https://github.com/GBellmont/Jesus_API/assets/61256397/4fd7019d-9259-484a-94cc-2feb1a64751b)

**Obs:** Lembrar de deixar um construtor vazio para o cast automático do Spring :)

#### Testes executados na API:
![image](https://github.com/GBellmont/Jesus_API/assets/61256397/59c2d8d1-7132-4ac1-9b3b-57590411b13b)
